### PR TITLE
fix: client context cancelled immediately, so there's always an error

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -60,13 +60,14 @@ func (self *Server) handle(context contextpkg.Context, connection *jsonrpc2.Conn
 	glspContext := glsp.Context{
 		Method:    request.Method,
 		RequestID: request.ID,
-		Notify: func(method string, params any) error {
-			return connection.Notify(context, method, params)
-		},
-		Call: func(method string, params any, result any) error {
-			return connection.Call(context, method, params, result)
-		},
-		Context: context,
+		Context:   context,
+	}
+
+	glspContext.Notify = func(method string, params any) error {
+		return connection.Notify(glspContext.Context, method, params)
+	}
+	glspContext.Call = func(method string, params any, result any) error {
+		return connection.Call(glspContext.Context, method, params, result)
 	}
 
 	if request.Params != nil {


### PR DESCRIPTION
Fixes an issue where all `Call`s returned `context canceled`. In the source repo, `Call` doesn't return an error, it only logs them. We updated to it do return `error`. The context passed to `Call` was the context passed into the jsonrpc stream, which is deterministically cancelled on startup:

https://github.com/poolsideai/glsp/blob/c85232132049f336ccfd02c1e044705b7511509d/server/connections.go#L18

This means that in the `select` [here](https://github.com/sourcegraph/jsonrpc2/blob/master/conn.go#L336) we'd return the cancellation error every time. 

I think this didn't cause an issue before because the actual _send_ of the call doesn't use contexts, and we've never needed to use a response value from Call yet (our calls are all more like notifies).

Since we don't pass context into notify/call right now, quickest fix is just to pass the context from glspContext, which can be set in handler.

Ideally we'd actually pass through the context.